### PR TITLE
ARC, modern Objective C, and dealloc

### DIFF
--- a/RMSSamplePlugin.xcodeproj/project.pbxproj
+++ b/RMSSamplePlugin.xcodeproj/project.pbxproj
@@ -248,6 +248,7 @@
 		9C736B7C094C726A001443E6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -264,6 +265,7 @@
 		9C736B7D094C726A001443E6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Source/RMSSamplePlugin.h
+++ b/Source/RMSSamplePlugin.h
@@ -17,11 +17,7 @@
 
 //***************************************************************************
 
-@interface RMSSamplePlugin : RWAbstractPlugin /*<RWPluginProtocol>*/
-{
-	RMSSamplePluginContentViewController *contentViewController;
-	RMSSamplePluginOptionsViewController *optionsViewController;
-}
+@interface RMSSamplePlugin : RWAbstractPlugin
 
 @property (nonatomic, copy) NSString *content;
 @property (nonatomic, assign) BOOL emitRawContent;

--- a/Source/RMSSamplePlugin.m
+++ b/Source/RMSSamplePlugin.m
@@ -14,6 +14,13 @@
 #import "RMSSamplePluginOptionsViewController.h"
 #import "RMSSamplePluginContentViewController.h"
 
+@interface RMSSamplePlugin ()
+
+@property (nonatomic, retain) RMSSamplePluginOptionsViewController *optionsAndConfigurationViewController;
+@property (nonatomic, retain) RMSSamplePluginContentViewController *userInteractionAndEditingViewController;
+
+@end
+
 //***************************************************************************
 
 @implementation RMSSamplePlugin
@@ -24,27 +31,27 @@
 
 - (NSView *)optionsAndConfigurationView
 {
-	if (optionsViewController == nil)
+	if (_optionsAndConfigurationViewController == nil)
 	{
-		optionsViewController = [[RMSSamplePluginOptionsViewController alloc] initWithRepresentedObject:self];
+		_optionsAndConfigurationViewController = [[RMSSamplePluginOptionsViewController alloc] initWithRepresentedObject:self];
 	}
 	
-	return optionsViewController.view;
+	return _optionsAndConfigurationViewController.view;
 }
 
 - (NSView *)userInteractionAndEditingView
 {
-	if (contentViewController == nil)
+	if (_userInteractionAndEditingViewController == nil)
 	{		
-		contentViewController = [[RMSSamplePluginContentViewController alloc] initWithRepresentedObject:self];
+		_userInteractionAndEditingViewController = [[RMSSamplePluginContentViewController alloc] initWithRepresentedObject:self];
 	}
 	
-	return contentViewController.view;
+	return _userInteractionAndEditingViewController.view;
 }
 
 - (id)contentHTML:(NSDictionary *)params
 {
-	NSString *string = (contentViewController.content) ?: self.content;
+	NSString *string = (self.userInteractionAndEditingViewController.content) ?: self.content;
 	if (string == nil) {
 		string = @"";
 	}
@@ -128,8 +135,8 @@
 
 - (void)finishSetup
 {
-	contentViewController = nil;
-	optionsViewController = nil;
+	self.userInteractionAndEditingViewController = nil;
+	self.optionsAndConfigurationViewController = nil;
 	
 	[self observeVisibleKeys];
 }
@@ -138,7 +145,7 @@
 {
 	[super encodeWithCoder:coder];
 	
-	[coder encodeObject:(contentViewController.content) ?: self.content forKey:@"Content String"];
+	[coder encodeObject:(self.userInteractionAndEditingViewController.content) ?: self.content forKey:@"Content String"];
 	[coder encodeObject:[NSNumber numberWithBool:self.emitRawContent] forKey:@"Emit Raw Content"];
 	[coder encodeObject:self.fileToken forKey:@"File Token"];
 }
@@ -178,8 +185,8 @@
 	[_content release];
 	[_fileToken release];
 	
-	[contentViewController release];
-	[optionsViewController release];
+	self.userInteractionAndEditingViewController = nil;
+	self.optionsAndConfigurationViewController = nil;
 	
     [super dealloc];
 }

--- a/Source/RMSSamplePlugin.m
+++ b/Source/RMSSamplePlugin.m
@@ -70,7 +70,7 @@
 
 - (NSNumber *)normaliseImages
 {
-	return [NSNumber numberWithUnsignedInt:0];
+	return @0U;
 }
 
 - (NSString *)overrideFileExtension
@@ -146,11 +146,11 @@
 	[super encodeWithCoder:coder];
 	
 	[coder encodeObject:(self.userInteractionAndEditingViewController.content) ?: self.content forKey:@"Content String"];
-	[coder encodeObject:[NSNumber numberWithBool:self.emitRawContent] forKey:@"Emit Raw Content"];
+	[coder encodeObject:@(self.emitRawContent) forKey:@"Emit Raw Content"];
 	[coder encodeObject:self.fileToken forKey:@"File Token"];
 }
 
-- (id)initWithCoder:(NSCoder *)coder
+- (instancetype)initWithCoder:(NSCoder *)coder
 {
 	self = [super initWithCoder:coder];
 	if (self == nil) {
@@ -166,7 +166,7 @@
 	return self;
 }
 
-- (id)init
+- (instancetype)init
 {
 	self = [super init];
 	if (self == nil) {
@@ -203,7 +203,7 @@
 	
 	if (plugin)
 	{
-		return [[NSArray arrayWithObject:plugin] objectEnumerator];
+		return [@[plugin] objectEnumerator];
 	}
 	
 	return nil;

--- a/Source/RMSSamplePlugin.m
+++ b/Source/RMSSamplePlugin.m
@@ -16,8 +16,8 @@
 
 @interface RMSSamplePlugin ()
 
-@property (nonatomic, retain) RMSSamplePluginOptionsViewController *optionsAndConfigurationViewController;
-@property (nonatomic, retain) RMSSamplePluginContentViewController *userInteractionAndEditingViewController;
+@property (nonatomic, strong) RMSSamplePluginOptionsViewController *optionsAndConfigurationViewController;
+@property (nonatomic, strong) RMSSamplePluginContentViewController *userInteractionAndEditingViewController;
 
 @end
 
@@ -181,14 +181,6 @@
 - (void)dealloc
 {
 	[self stopObservingVisibleKeys];
-	
-	[_content release];
-	[_fileToken release];
-	
-	self.userInteractionAndEditingViewController = nil;
-	self.optionsAndConfigurationViewController = nil;
-	
-    [super dealloc];
 }
 
 //***************************************************************************
@@ -211,7 +203,7 @@
 	
 	if (plugin)
 	{
-		return [[NSArray arrayWithObject:[plugin autorelease]] objectEnumerator];
+		return [[NSArray arrayWithObject:plugin] objectEnumerator];
 	}
 	
 	return nil;
@@ -231,7 +223,7 @@
 {
 	NSBundle *bundle = [RMSSamplePlugin bundle];
 	NSString *iconFilename = [bundle objectForInfoDictionaryKey:@"CFBundleIconFile"];
-	return [[[NSImage alloc] initWithContentsOfFile:[bundle pathForImageResource:iconFilename]] autorelease];
+	return [[NSImage alloc] initWithContentsOfFile:[bundle pathForImageResource:iconFilename]];
 }
 
 + (NSString *)pluginDescription;

--- a/Source/RMSSamplePluginContentViewController.h
+++ b/Source/RMSSamplePluginContentViewController.h
@@ -17,7 +17,7 @@
 
 @property (weak, nonatomic, readonly) NSString *content;
 
-- (id)initWithRepresentedObject:(id)object;
+- (instancetype)initWithRepresentedObject:(id)object NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/Source/RMSSamplePluginContentViewController.h
+++ b/Source/RMSSamplePluginContentViewController.h
@@ -15,7 +15,7 @@
 	IBOutlet RWHTMLView *htmlView;
 }
 
-@property (nonatomic, readonly) NSString *content;
+@property (weak, nonatomic, readonly) NSString *content;
 
 - (id)initWithRepresentedObject:(id)object;
 

--- a/Source/RMSSamplePluginContentViewController.m
+++ b/Source/RMSSamplePluginContentViewController.m
@@ -13,6 +13,12 @@
 #import "RMSSamplePlugin.h"
 #import "RMSSamplePluginContentViewController.h"
 
+@interface RMSSamplePluginContentViewController ()
+
+@property (nonatomic, assign) RMSSamplePlugin *plugin;
+
+@end
+
 //***************************************************************************
 
 @implementation RMSSamplePluginContentViewController
@@ -26,14 +32,14 @@
 
 - (void)textDidChange:(NSNotification *)notification
 {
-	RMSSamplePlugin *p = self.representedObject;
+	RMSSamplePlugin *p = self.plugin;
 	
 	[p broadcastPluginChanged];
 }
 
 - (void)awakeFromNib
 {
-	RMSSamplePlugin *p = self.representedObject;
+	RMSSamplePlugin *p = self.plugin;
 	NSString *string = p.content;
 	
 	if (string) {
@@ -50,7 +56,7 @@
 		return nil;
 	}
 	
-	[self setRepresentedObject:object];
+	[self setPlugin:object];
 	
 	return self;
 }

--- a/Source/RMSSamplePluginContentViewController.m
+++ b/Source/RMSSamplePluginContentViewController.m
@@ -27,7 +27,7 @@
 
 - (NSString *)content
 {
-	return [htmlView string];
+	return htmlView.string;
 }
 
 - (void)textDidChange:(NSNotification *)notification
@@ -43,20 +43,20 @@
 	NSString *string = p.content;
 	
 	if (string) {
-		[htmlView setString:string];
+		htmlView.string = string;
 	}
 	
 	[htmlView setHasBorder:NO];
 }
 
-- (id)initWithRepresentedObject:(id)object
+- (instancetype)initWithRepresentedObject:(id)object
 {
 	self = [super initWithNibName:@"RMSSamplePluginContentView" bundle:[RMSSamplePlugin bundle]];
 	if (self == nil) {
 		return nil;
 	}
 	
-	[self setPlugin:object];
+	self.plugin = object;
 	
 	return self;
 }

--- a/Source/RMSSamplePluginContentViewController.m
+++ b/Source/RMSSamplePluginContentViewController.m
@@ -15,7 +15,7 @@
 
 @interface RMSSamplePluginContentViewController ()
 
-@property (nonatomic, assign) RMSSamplePlugin *plugin;
+@property (nonatomic, weak) RMSSamplePlugin *plugin;
 
 @end
 

--- a/Source/RMSSamplePluginOptionsViewController.h
+++ b/Source/RMSSamplePluginOptionsViewController.h
@@ -12,7 +12,7 @@
 
 @interface RMSSamplePluginOptionsViewController : NSViewController
 
-- (id)initWithRepresentedObject:(id)object;
+- (instancetype)initWithRepresentedObject:(id)object NS_DESIGNATED_INITIALIZER;
 
 - (IBAction)chooseFile:(id)sender;
 - (IBAction)testFileAccess:(id)sender;

--- a/Source/RMSSamplePluginOptionsViewController.m
+++ b/Source/RMSSamplePluginOptionsViewController.m
@@ -13,6 +13,12 @@
 #import "RMSSamplePlugin.h"
 #import "RMSSamplePluginOptionsViewController.h"
 
+@interface RMSSamplePluginOptionsViewController ()
+
+@property (nonatomic, assign) RMSSamplePlugin *plugin;
+
+@end
+
 //***************************************************************************
 
 @implementation RMSSamplePluginOptionsViewController
@@ -24,7 +30,7 @@
 		return nil;
 	}
 	
-	[self setRepresentedObject:object];
+	[self setPlugin:object];
 	
 	return self;
 }
@@ -39,7 +45,7 @@
 		
 		NSError *bookmarkError = nil;
 		NSURL *fileURL = [openPanel URL];
-		RMSSamplePlugin *pluginInstance = self.representedObject;
+		RMSSamplePlugin *pluginInstance = self.plugin;
 		NSString *newFileToken = [pluginInstance registerFileURL:fileURL error:&bookmarkError];
 		if (newFileToken == nil) {
 			NSLog(@"Failed to bookmark file with error: %@", bookmarkError);
@@ -56,7 +62,7 @@
 
 - (IBAction)testFileAccess:(id)sender
 {
-	RMSSamplePlugin *pluginInstance = self.representedObject;
+	RMSSamplePlugin *pluginInstance = self.plugin;
 	NSLog(@"fileToken: %@", pluginInstance.fileToken);
 	if (pluginInstance.fileToken == nil) {
 		NSBeep();

--- a/Source/RMSSamplePluginOptionsViewController.m
+++ b/Source/RMSSamplePluginOptionsViewController.m
@@ -15,7 +15,7 @@
 
 @interface RMSSamplePluginOptionsViewController ()
 
-@property (nonatomic, assign) RMSSamplePlugin *plugin;
+@property (nonatomic, weak) RMSSamplePlugin *plugin;
 
 @end
 

--- a/Source/RMSSamplePluginOptionsViewController.m
+++ b/Source/RMSSamplePluginOptionsViewController.m
@@ -23,14 +23,14 @@
 
 @implementation RMSSamplePluginOptionsViewController
 
-- (id)initWithRepresentedObject:(id)object
+- (instancetype)initWithRepresentedObject:(id)object
 {
 	self = [super initWithNibName:@"RMSSamplePluginOptionsView" bundle:[RMSSamplePlugin bundle]];
 	if (self == nil) {
 		return nil;
 	}
 	
-	[self setPlugin:object];
+	self.plugin = object;
 	
 	return self;
 }
@@ -44,7 +44,7 @@
 		}
 		
 		NSError *bookmarkError = nil;
-		NSURL *fileURL = [openPanel URL];
+		NSURL *fileURL = openPanel.URL;
 		RMSSamplePlugin *pluginInstance = self.plugin;
 		NSString *newFileToken = [pluginInstance registerFileURL:fileURL error:&bookmarkError];
 		if (newFileToken == nil) {
@@ -93,7 +93,7 @@
 	
 	[fileURL stopAccessingSecurityScopedResource];
 	
-	NSLog(@"Read data of %ld bytes.", [fileData length]);
+	NSLog(@"Read data of %ld bytes.", fileData.length);
 }
 
 @end


### PR DESCRIPTION
This pull request does the following things:
- Removes retain cycles in the sample plugin, so that it is successfully deallocated when a project is closed
- Enables ARC
- Updates some code to modern Objective C
